### PR TITLE
scripts: Set bash in magic line ("shebang")

### DIFF
--- a/build_all.sh
+++ b/build_all.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-#
+#!/bin/bash
+
 # various options for cmake based builds:
 # CMAKE_BUILD_TYPE can specify a build (debug|release|...) build type
 # LIB_SUFFIX can set the ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}

--- a/build_all_autotools_projects.sh
+++ b/build_all_autotools_projects.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-#
+#!/bin/bash
+
 # various options for cmake based builds:
 # CMAKE_BUILD_TYPE can specify a build (debug|release|...) build type
 # LIB_SUFFIX can set the ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}

--- a/build_all_cmake_projects.sh
+++ b/build_all_cmake_projects.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#
+
 # various options for cmake based builds:
 # CMAKE_BUILD_TYPE can specify a build (debug|release|...) build type
 # LIB_SUFFIX can set the ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 LAST_LXQT_VER="0.8.0"
 CURRENT_LXQT_VER="HEAD"
 

--- a/clean_all_cmake_projects.sh
+++ b/clean_all_cmake_projects.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 CMAKE_REPOS=" \
 	libqtxdg \
 	liblxqt \

--- a/create_tarballs.sh
+++ b/create_tarballs.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+
 mkdir -p release
 
 if env | grep -q ^CMAKE_GENERATOR= ; then

--- a/uninstall_all_cmake_projects.sh
+++ b/uninstall_all_cmake_projects.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 INSTALL_MANIFEST="install_manifest.txt"
 


### PR DESCRIPTION
As pointed out in #1154 some of the scripts feature bash-specific syntax while the magic line points to `/bin/sh` which may in turn point to a different shell.
Of course it could be attempted to get rid of that bash-specific syntax but I figure using bash by default is the more reasonable thing to do right now.

PR is setting bash in all scripts including those without specific syntax as consistency probably makes sense nevertheless.
(And adds a blank second line as this makes the scripts a bit better to read, IMO.)