### PR TITLE
Updates & centralize cmake repos list

### DIFF
--- a/build_all_cmake_projects.sh
+++ b/build_all_cmake_projects.sh
@@ -17,36 +17,7 @@
 # $ CMAKE_BUILD_TYPE=debug CMAKE_GENERATOR=Ninja CC=clang CXX=clang++ DO_INSTALL=0 ./build_all.sh
 # etc.
 
-CMAKE_REPOS=" \
-	lxqt-build-tools \
-	libqtxdg \
-	liblxqt \
-	libsysstat \
-	lxqt-session \
-	lxqt-qtplugin \
-	lxqt-globalkeys \
-	lxqt-notificationd \
-	lxqt-about \
-	lxqt-common \
-	lxqt-config \
-	lxqt-admin \
-	lxqt-openssh-askpass \
-	lxqt-panel \
-	lxqt-policykit \
-	lxqt-powermanagement \
-	lxqt-runner \
-	libfm-qt \
-	pcmanfm-qt \
-	lxqt-sudo \
-	pavucontrol-qt"
-
-OPTIONAL_CMAKE_REPOS=" \
-	qtermwidget \
-	qterminal \
-	lximage-qt \
-	compton-conf \
-	obconf-qt"
-
+source "cmake_repos.list"
 
 if [[ -n "$LXQT_JOB_NUM" ]]; then
     JOB_NUM="$LXQT_JOB_NUM"

--- a/clean_all_cmake_projects.sh
+++ b/clean_all_cmake_projects.sh
@@ -1,30 +1,8 @@
 #!/bin/bash
 
-CMAKE_REPOS=" \
-	libqtxdg \
-	liblxqt \
-	libsysstat \
-	lxqt-session \
-	lxqt-qtplugin \
-	lxqt-globalkeys \
-	lxqt-notificationd \
-	lxqt-about \
-	lxqt-common \
-	lxqt-config \
-	lxqt-admin \
-	lxqt-openssh-askpass \
-	lxqt-panel \
-	lxqt-policykit \
-	lxqt-powermanagement \
-	lxqt-runner \
-	libfm-qt \
-	pcmanfm-qt \
-	lximage-qt \
-	lxqt-sudo \
-	compton-conf \
-	obconf-qt"
+source "cmake_repos.list"
 
-for d in $CMAKE_REPOS
+for d in ${CMAKE_REPOS} ${OPTIONAL_CMAKE_REPOS}
 do
 	echo "removing $d/build"
 	rm -rf $d/build

--- a/cmake_repos.list
+++ b/cmake_repos.list
@@ -1,0 +1,30 @@
+CMAKE_REPOS=" \
+	lxqt-build-tools \
+	libqtxdg \
+	liblxqt \
+	libsysstat \
+	lxqt-session \
+	lxqt-qtplugin \
+	lxqt-globalkeys \
+	lxqt-notificationd \
+	lxqt-about \
+	lxqt-common \
+	lxqt-config \
+	lxqt-admin \
+	lxqt-openssh-askpass \
+	lxqt-panel \
+	lxqt-policykit \
+	lxqt-powermanagement \
+	lxqt-runner \
+	libfm-qt \
+	pcmanfm-qt \
+	lxqt-sudo \
+	pavucontrol-qt"
+
+OPTIONAL_CMAKE_REPOS=" \
+	qtermwidget \
+	qterminal \
+	lximage-qt \
+	compton-conf \
+	obconf-qt"
+

--- a/uninstall_all_cmake_projects.sh
+++ b/uninstall_all_cmake_projects.sh
@@ -2,31 +2,9 @@
 
 INSTALL_MANIFEST="install_manifest.txt"
 
-CMAKE_REPOS=" \
-	libqtxdg \
-	liblxqt \
-	libsysstat \
-	lxqt-session \
-	lxqt-qtplugin \
-	lxqt-globalkeys \
-	lxqt-notificationd \
-	lxqt-about \
-	lxqt-common \
-	lxqt-config \
-	lxqt-admin \
-	lxqt-openssh-askpass \
-	lxqt-panel \
-	lxqt-policykit \
-	lxqt-powermanagement \
-	lxqt-runner \
-	libfm-qt \
-	pcmanfm-qt \
-	lximage-qt \
-	lxqt-sudo \
-	compton-conf \
-	obconf-qt"
+source "cmake_repos.list"
 
-for d in ${CMAKE_REPOS}
+for d in ${CMAKE_REPOS} ${OPTIONAL_CMAKE_REPOS}
 do
     INSTALL_MANIFEST_FULL_PATH="${d}/build/${INSTALL_MANIFEST}"
     if [ -f "${INSTALL_MANIFEST_FULL_PATH}" ]


### PR DESCRIPTION
Keep the list in one place only.
* build_all_cmake_projects, clean_all_cmake_projects and
uninstall_all_cmake_projects scripts use the cmake_repos.list file.
* Added OPTIONAL_CMAKE_REPOS to the clean_all_cmake_projects and
uninstall_all_cmake_projects scripts.